### PR TITLE
fix: ga for small sample size

### DIFF
--- a/sycofinder/ga.py
+++ b/sycofinder/ga.py
@@ -149,7 +149,7 @@ def main(input_data, var_names, mutation_shrink_factor=1.0):
     varSTD = [mutation_shrink_factor * (m - n) / 5.0 for m, n in zip(UB, LB)]
     # Note: we always compute only 1 generation (no GA in silico yet)
     migration_rate, mutation_rate = 0.1, 0.2
-    tournament_size = 4
+    tournament_size = 4 if len(pop) > 4 else len(pop)-1
     new_pop = []
     for _i in range(len(pop)):
         if random.random() < migration_rate:  # migration


### PR DESCRIPTION
The GA implementation breaks for sample size 4 since tournament size was hardcoded to 4,  causing the GA to hang indefinitely in this loop
https://github.com/materialscloud-org/sycofinder/blob/510a0349e450d2d249ed276f213684c91875cf8e/sycofinder/ga.py#L87-L88